### PR TITLE
NETOBSERV-987: Adding NetObserv must-gather support

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,9 @@
+**Release note**:
+<!--  Write your release note:
+1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
+2. If no release note is required, just write "NONE".
+-->
+```release-note
+
+```
+

--- a/.github/workflows/build-push-images.yaml
+++ b/.github/workflows/build-push-images.yaml
@@ -1,0 +1,31 @@
+name: Build and Push Images
+
+on:
+  push:
+    branches:
+      - main
+      - release-*
+jobs:
+  build_push:
+    if: (github.repository == 'netobserv/must-gather')
+    name: Build and Push Images
+    runs-on: ubuntu-latest
+    env:
+      QUAY_USERNAME: ${{ secrets.QUAY_USERNAME }}
+      QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}
+      REGISTRY_NAMESPACE: netobserv
+    steps:
+      - name: Checkout the latest code
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.ref }}
+      - name: Check build
+        run: |
+          make check MUST_GATHER_IMAGE=$REGISTRY_NAMESPACE/must-gather
+      - name: Build image
+        run: |
+          make docker-build MUST_GATHER_IMAGE=$REGISTRY_NAMESPACE/must-gather
+      - name: Push image
+        run: |
+          echo $QUAY_PASSWORD | docker login -u $QUAY_USERNAME --password-stdin quay.io
+          make build MUST_GATHER_IMAGE=$REGISTRY_NAMESPACE/must-gather

--- a/.github/workflows/pr-sanity.yaml
+++ b/.github/workflows/pr-sanity.yaml
@@ -1,0 +1,28 @@
+name: Sanity Test
+
+on:
+  pull_request:
+    branches:
+    - main
+    - release-*
+jobs:
+  build_push:
+    if: (github.repository == 'netobserv/must-gather')
+    name: Pull Request Sanity
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+      with:
+        ref: ${{ github.ref }}
+    - uses: actions/setup-go@v2
+      with:
+        go-version: '1.19' # The Go version to download (if necessary) and use.
+    - name: Run ShellCheck
+      uses: ludeeus/action-shellcheck@master
+      env:
+        SHELLCHECK_OPTS: -a -e SC2016 --source-path=./collection-scripts
+      with:
+         check_together: 'yes'
+         version: v0.8.0
+         scandir: './collection-scripts/'

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM quay.io/openshift/origin-must-gather:4.12.0 as builder
+
+FROM quay.io/centos/centos:stream8
+
+COPY --from=builder /usr/bin/oc /usr/bin/oc
+
+# Copy all collection scripts to /usr/bin
+COPY collection-scripts/* /usr/bin/
+
+ENTRYPOINT /usr/bin/gather

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,28 @@
+IMAGE_REGISTRY ?= quay.io
+IMAGE_TAG ?= latest
+
+# MUST_GATHER_IMAGE needs to be passed explicitly to avoid accidentally pushing to netobserv/must-gather
+check-image-env: ## Check MUST_GATHER_IMAGE make sure its set.
+ifndef MUST_GATHER_IMAGE
+	$(error MUST_GATHER_IMAGE is not set.)
+endif
+
+.PHONY: build
+build: check-image-env docker-build docker-push ## check MUST_GATHER_IMAGE, build and push NetObserv collection docker image.
+
+# check
+check: ## Run shellcheck against bash collection scripts.
+	shellcheck -e SC2016 collection-scripts/*
+
+.PHONY: docker-build
+docker-build: check-image-env ## Build NetObserv collection docker image.
+	docker build -t ${IMAGE_REGISTRY}/${MUST_GATHER_IMAGE}:${IMAGE_TAG} .
+
+.PHONY: docker-push
+docker-push: check-image-env ## Push NetObserv collection docker image.
+	docker push ${IMAGE_REGISTRY}/${MUST_GATHER_IMAGE}:${IMAGE_TAG}
+
+
+.PHONY: help
+help: ## Display this help.
+	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_0-9-]+:.*?##/ { printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)

--- a/OWNERS
+++ b/OWNERS
@@ -1,0 +1,16 @@
+approvers:
+- eranra
+- jotak
+- jpinsonneau
+- msherif1234
+- oliviercazade
+- ronensc
+options: {}
+reviewers:
+- eranra
+- jotak
+- jpinsonneau
+- msherif1234
+- oliviercazade
+- ronensc
+- stleerh

--- a/README.md
+++ b/README.md
@@ -1,1 +1,75 @@
-# must-gather
+# NetObserv must-gather
+
+`must-gather` is a tool built on top of [OpenShift must-gather](https://github.com/openshift/must-gather)
+that expands its capabilities to gather NetObserv information.
+
+## Usage
+```sh
+oc adm must-gather --image=quay.io/netobserv/must-gather
+```
+
+The command above will create a local directory with a dump of the NetObserv Operator state.
+Note that this command will only get data related to the NetObserv part of the OpenShift cluster.
+
+You will get a dump of:
+- The NetObserv operator pod logs
+- The NetObserv FlowCollector CRD's definition
+- Dump of Loki as well as NetObserv agent pods logs
+
+In order to get data about other parts of the cluster (not specific to NetObserv) you should
+run `oc adm must-gather` (without passing a custom image). Run `oc adm must-gather -h` to see more options.
+
+### Flags
+
+`must-gather` provides a series of options to select which information to
+collect from the cluster. The tool will always collect all control-plane logs and information.
+Optional collectors can be enabled with CLI options.
+
+
+To run only the default collectors:
+```sh
+oc adm must-gather --image=quay.io/netobserv/must-gather -- /usr/bin/gather
+```
+
+### Help Menu
+
+At any time you can check the help menu for usage details of the NetObserv must-gather
+
+```sh
+oc adm must-gather --image=quay.io/netobserv/must-gather -- /usr/bin/gather --help
+```
+
+```
+Usage: oc adm must-gather --image=quay.io/netobserv/must-gather -- /usr/bin/gather [params...]
+
+  A client tool for gathering NetObserv information in an OpenShift cluster
+
+  Available options:
+
+  > To see this help menu and exit use
+  --help
+
+  > The tool will always collect all control-plane logs and information.
+  > This will include:
+  > - crds
+  > - resources
+  > - webhooks
+
+```
+
+## Development
+You can build the image locally using the Dockerfile included.
+
+A `makefile` is also provided. To use it, you must pass a repository via the command-line using the variable `MUST_GATHER_IMAGE`.
+You can also specify the registry using the variable `IMAGE_REGISTRY` (default is [quay.io](https://quay.io)) and the tag via `IMAGE_TAG` (default is `latest`).
+
+The targets for `make` are as follows:
+- `build`: builds the image with the supplied name and pushes it
+- `docker-build`: builds the image but does not push it
+- `docker-push`: pushes an already-built image
+
+For example:
+```sh
+make build MUST_GATHER_IMAGE=netobserv/must-gather
+```
+would build the local repository as `quay.io/netobserv/must-gather:latest` and then push it.

--- a/collection-scripts/common.sh
+++ b/collection-scripts/common.sh
@@ -1,0 +1,13 @@
+#!/bin/bash -x
+
+DIR_NAME=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+export BASE_COLLECTION_PATH="${BASE_COLLECTION_PATH:-/must-gather}"
+
+function check_command {
+    if [[ -z "$USR_BIN_GATHER" ]]; then
+        echo "This script should not be directly executed." 1>&2
+        echo "Please check \"${DIR_NAME}/gather --help\" for execution options." 1>&2
+        exit 1
+    fi
+}
+

--- a/collection-scripts/gather
+++ b/collection-scripts/gather
@@ -1,0 +1,74 @@
+#!/bin/bash
+
+export BASE_COLLECTION_PATH="${BASE_COLLECTION_PATH:-/must-gather}"
+DIR_NAME=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
+function main() {
+  declare mandatory_scripts=(
+    "crds"
+    "resources"
+    "webhooks"
+  )
+  declare requested_scripts=("${mandatory_scripts[@]}")
+
+  parse_flags "$@"
+  run_scripts
+  sync
+  exit 0
+}
+
+function parse_flags {
+  while :; do
+    case $1 in
+      --help)
+        help
+        exit 0
+        ;;
+      --images)
+        requested_scripts+=("images")
+        ;;
+      --)
+        shift
+        break
+        ;;
+      -?*)
+        printf 'WARN: Unknown option (ignored): %s\n' "$1" >&2
+        ;;
+      *) # Default case: No more options, so break out of the loop.
+        break
+    esac
+    shift
+  done
+}
+
+function help {
+    echo "\
+Usage: oc adm must-gather --image=quay.io/netobserv/must-gather -- /usr/bin/gather [params...]
+
+  A client tool for gathering NetObserv information in an OpenShift cluster
+
+  Available options:
+
+  > To see this help menu and exit use
+  --help
+
+  > The tool will always collect all control-plane logs and information.
+  > This will include:"
+    for collector in "${mandatory_scripts[@]}" ; do
+    echo "  > - $collector"
+    done
+    echo "\
+
+"
+}
+
+function run_scripts {
+  for script in "${requested_scripts[@]}";
+  do
+    script_name="gather_${script}"
+    echo "running ${script_name}"
+    eval USR_BIN_GATHER=1 "${DIR_NAME}/${script_name}"
+  done
+}
+
+main "$@"; exit

--- a/collection-scripts/gather_crds
+++ b/collection-scripts/gather_crds
@@ -1,0 +1,12 @@
+#!/bin/bash -x
+
+DIR_NAME=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+source "${DIR_NAME}/common.sh"
+check_command
+
+CRD=$(/usr/bin/oc get crd | grep netobserv.io | awk '{print $1}')
+
+# Run the collection of crds using must-gather
+echo "${CRD[@]}" | tr ' ' '\n' | xargs -t -I{}  --max-args=1 sh -c '/usr/bin/oc adm inspect crd --dest-dir ${BASE_COLLECTION_PATH} $1' -- {}
+
+exit 0

--- a/collection-scripts/gather_resources
+++ b/collection-scripts/gather_resources
@@ -1,0 +1,25 @@
+#!/bin/bash -x
+
+DIR_NAME=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+source "${DIR_NAME}/common.sh"
+check_command
+
+NO_NS="$(oc get subs -A -o template --template '{{range .items}}{{if eq .spec.name "netobserv-operator"}}{{.metadata.namespace}}{{end}}{{end}}')"
+if [ -z "${NO_NS}" ]; then
+    echo "INFO: Network Observability namespace is not detected. Skipping."
+    exit 0
+fi
+
+CRD=$(/usr/bin/oc get crd | grep netobserv.io | awk '{print $1}')
+obj=$(/usr/bin/oc get "${CRD}" -o custom-columns=:metadata.name --no-headers)
+fc_ns=$(/usr/bin/oc get "${CRD}" "${obj}" --output=jsonpath='{.spec.namespace}')
+
+if [ -z "${fc_ns}" ]; then
+    echo "INFO: Network Observability flow collector object namespace is not detected. Skipping."
+    exit 0
+fi
+
+"${DIR_NAME}"/version
+oc adm inspect --dest-dir "${BASE_COLLECTION_PATH}" "ns/${NO_NS}"
+oc adm inspect --dest-dir "${BASE_COLLECTION_PATH}" "ns/${fc_ns}"
+oc adm inspect --dest-dir "${BASE_COLLECTION_PATH}" "ns/${fc_ns}-privileged"

--- a/collection-scripts/gather_webhooks
+++ b/collection-scripts/gather_webhooks
@@ -1,0 +1,23 @@
+#!/bin/bash -x
+
+DIR_NAME=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+source "${DIR_NAME}/common.sh"
+check_command
+
+function gather_validating_wh() {
+  webhooks_collection_path=${BASE_COLLECTION_PATH}/webhooks/validating/${1}
+  mkdir -p "${webhooks_collection_path}"
+
+  /usr/bin/oc get validatingwebhookconfiguration "${1}" -o yaml | grep -vi cabundle > "${webhooks_collection_path}/validatingwebhookconfiguration.yaml"
+
+  # fetch the service associated with webhook
+  /usr/bin/oc get validatingwebhookconfiguration "${1}" -o=go-template --template='{{ range .webhooks }}-n {{.clientConfig.service.namespace}} {{.clientConfig.service.name}}{{ "\n" }}{{ end }}' | uniq | xargs /usr/bin/oc get service -o yaml > "${webhooks_collection_path}/service.yaml"
+}
+
+export -f gather_validating_wh
+
+validating_wh=$(/usr/bin/oc get validatingwebhookconfiguration -o custom-columns=NAME:.metadata.name --no-headers | grep -i flowcollectorconversionwebhook)
+echo "${validating_wh[@]}" | tr ' ' '\n' | xargs -t -I{}  --max-args=1 sh -c 'gather_validating_wh $1' -- {}
+
+
+exit 0


### PR DESCRIPTION
netobserv must gather scripts to collect pods logs/crd and webhook configs 
for manual testing
1- build private docker image
```sh
$ make build MUST_GATHER_IMAGE=mmahmoud/must-gather-netobser
```
2- collect netobserv plus the regular must-gather collection
```sh
$ oc adm must-gather \
 --image-stream=openshift/must-gather \ 
 --image=quay.io/mmahmoud/must-gather-netobserv 
```

3- collect only netobserv must-gather
```sh
$ oc adm must-gather --image=quay.io/mmahmoud/must-gather-netobserv 
```
4- unit-testing

- check logs using `omg` tool
```sh
$ omg use must-gather.local.5361505580896984408/quay-io-mmahmoud-must-gather-netobserv-sha256-f8acf7369c2a0b13c43cbf02937287d987cef0573a561c7d3636af104691c465/
Using:  /home/mmahmoud/data/test-noo-mg/must-gather.local.5361505580896984408/quay-io-mmahmoud-must-gather-netobserv-sha256-f8acf7369c2a0b13c43cbf02937287d987cef0573a561c7d3636af104691c465
$ omg get pods -n openshift-netobserv-operator
NAME                                           READY  STATUS   RESTARTS  AGE
netobserv-controller-manager-6f4c6fff45-42jzt  2/2    Running  0         3m16s
$ omg get pods -n netobserv
NAME                               READY  STATUS   RESTARTS  AGE
flowlogs-pipeline-2kprc            1/1    Running  0         2m14s
flowlogs-pipeline-42bfm            1/1    Running  0         2m14s
flowlogs-pipeline-4979m            1/1    Running  0         2m14s
flowlogs-pipeline-bnqdv            1/1    Running  0         2m14s
flowlogs-pipeline-hn29k            1/1    Running  0         2m14s
flowlogs-pipeline-r4b6m            1/1    Running  0         2m14s
netobserv-plugin-7ff87b8687-dbcjw  1/1    Running  0         2m15s
$ omg get pods -n netobserv-privileged
NAME                        READY  STATUS   RESTARTS  AGE
netobserv-ebpf-agent-c8p28  1/1    Running  0         2m15s
netobserv-ebpf-agent-lg7rq  1/1    Running  0         2m15s
netobserv-ebpf-agent-p4ftv  1/1    Running  0         2m15s
netobserv-ebpf-agent-t6q4f  1/1    Running  0         2m15s
netobserv-ebpf-agent-thrvz  1/1    Running  0         2m15s
netobserv-ebpf-agent-zj2lp  1/1    Running  0         2m15s
```

- webhook logs
```sh
$ ls -l must-gather.local.1750696864492964063/quay-io-mmahmoud-must-gather-netobserv-sha256-e7264044745d117ea12e5037093b54beac4517ef5d2c4e155110ee3f2de5e2e5/webhooks/validating/flowcollectorconversionwebhook.netobserv.io-xq9qf/
total 8
-rw-r--r--. 1 mmahmoud mmahmoud  937 Apr 24 17:19 service.yaml
-rw-r--r--. 1 mmahmoud mmahmoud 1214 Apr 24 17:19 validatingwebhookconfiguration.yaml
```

- crd
```sh
$ ls -l must-gather.local.1750696864492964063/quay-io-mmahmoud-must-gather-netobserv-sha256-e7264044745d117ea12e5037093b54beac4517ef5d2c4e155110ee3f2de5e2e5/cluster-scoped-resources/apiextensions.k8s.io/customresourcedefinitions/
total 256
-rwxr-xr-x. 1 mmahmoud mmahmoud 262123 Apr 24 17:19 flowcollectors.flows.netobserv.io.yaml
```