### PR TITLE
collect flowcollector object

### DIFF
--- a/collection-scripts/gather_resources
+++ b/collection-scripts/gather_resources
@@ -21,6 +21,7 @@ if [ -z "${fc_ns}" ]; then
 fi
 
 "${DIR_NAME}"/version
+oc adm inspect --dest-dir "${BASE_COLLECTION_PATH}" "${CRD}/${obj}"
 oc adm inspect --dest-dir "${BASE_COLLECTION_PATH}" "ns/${NO_NS}"
 oc adm inspect --dest-dir "${BASE_COLLECTION_PATH}" "ns/${fc_ns}"
 oc adm inspect --dest-dir "${BASE_COLLECTION_PATH}" "ns/${fc_ns}-privileged"


### PR DESCRIPTION
Now collect flowcollector object as well, tested locally, it should dump the resource at:
```
$ ls -lrt /tmp/must-gather-test/quay-io-rhn-support-memodi-must-gather-sha256-f1979aab6be53e7a2c19bd3a643a12a29265467b0d0d7907d4cbca249654ca5c/cluster-scoped-resources/flows.netobserv.io/flowcollectors
total 32
-rwxr-xr-x  1 memodi  wheel  14995 Apr 12 14:44 cluster.yaml
```